### PR TITLE
travis CI status image and .yml tweaks to resolve failed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: java
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -8,6 +9,9 @@ cache:
     - $HOME/.gradle/wrapper/
 branches:
   only:
-  - master
+    - master
+    - feature/travis_ci
 before_install:
- - chmod +x gradlew
+  - chmod +x gradlew
+script:
+  - ./gradlew clean check --no-daemon --info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## gradle crossbuild scala plugin
+[![Build Status](https://travis-ci.org/prokod/gradle-crossbuild-scala.svg?branch=master)](https://travis-ci.org/prokod/gradle-crossbuild-scala)
 
 ### Getting the plugin
 ----------------------


### PR DESCRIPTION
This PR adds travis CI status image to readme and fixes the following failed travis CI attempts
- Caused by: org.gradle.launcher.daemon.client.DaemonDisappearedException
- No output has been received in the last 10m0s ...

by .travis.yml tweaks