### PR TITLE
To handle concisely Scala 3rd lib deps resolution on test configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'codenarc'
 targetCompatibility = '1.6'
 
 group = 'com.github.prokod'
-version = '0.3.0'
+version = '0.3.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginCompileMultiModuleTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginCompileMultiModuleTest.groovy
@@ -39,8 +39,8 @@ class CrossBuildPluginCompileMultiModuleTest extends CrossBuildGradleRunnerSpec 
         libBuildFile = file('lib/build.gradle')
         libScalaFile = file('lib/src/main/scala/HelloWorldLibApi.scala')
         libJavaFile = file('lib/src/main/java/HelloWorldLibImpl.java')
-        appBuildFile = file('mapp/build.gradle')
-        appScalaFile = file('mapp/src/main/scala/HelloWorldApp.scala')
+        appBuildFile = file('app/build.gradle')
+        appScalaFile = file('app/src/main/scala/HelloWorldApp.scala')
     }
 
     @Unroll
@@ -49,7 +49,7 @@ class CrossBuildPluginCompileMultiModuleTest extends CrossBuildGradleRunnerSpec 
         // root project settings.gradle
         settingsFile << """
 include 'lib'
-include 'mapp'
+include 'app'
 """
 
         buildFile << """
@@ -193,8 +193,8 @@ dependencies {
 
         fileExists("$dir.root.absolutePath/lib/build/libs/lib_2.10.jar")
         fileExists("$dir.root.absolutePath/lib/build/libs/lib_2.11.jar")
-        fileExists("$dir.root.absolutePath/mapp/build/libs/mapp_2.10.jar")
-        fileExists("$dir.root.absolutePath/mapp/build/libs/mapp_2.11.jar")
+        fileExists("$dir.root.absolutePath/app/build/libs/app_2.10.jar")
+        fileExists("$dir.root.absolutePath/app/build/libs/app_2.11.jar")
 
         def pom210 = new File("${dir.root.absolutePath}${File.separator}lib${File.separator}build${File.separator}generated-pom_2.10.xml").text
         def pom211 = new File("${dir.root.absolutePath}${File.separator}lib${File.separator}build${File.separator}generated-pom_2.11.xml").text

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/utils/DependencyInsightsTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/utils/DependencyInsightsTest.groovy
@@ -17,6 +17,16 @@ class DependencyInsightsTest extends Specification {
             scalaVersion == '2.11'
     }
 
+    def "When parseDependencyName given a scala lib dependency with '_suffix' it should return correctly"() {
+        given:
+        def dep = new DefaultExternalModuleDependency('some.group', 'somescalalib_2.11_suffix', '1.2.3')
+        when:
+        def (baseName, scalaVersion) = DependencyInsights.parseDependencyName(dep)
+        then:
+        baseName == 'some.group:somescalalib'
+        scalaVersion == '2.11'
+    }
+
     def "When parseDependencyName given a complex scala lib dependency it should return correctly"() {
         given:
             def dep = new DefaultExternalModuleDependency('some.group', 'somescalalib_2.11_2.2.1', '1.2.3')
@@ -31,20 +41,25 @@ class DependencyInsightsTest extends Specification {
         given:
             def dep1 = new DefaultExternalModuleDependency('some.group', 'somescalalib_2.11', '1.2.3')
             def dep2 = new DefaultExternalModuleDependency('some.group', 'someotherscalalib_?', '1.2.4')
-            def dep3 = new DefaultExternalModuleDependency('some.group', 'yasomecalalib_2.10', '1.2.5')
-            def dependencySet = new DefaultDependencySet(
+            def dep3 = new DefaultExternalModuleDependency('some.group', 'yasomecalalib_?_suffix', '1.2.5')
+            def dep4 = new DefaultExternalModuleDependency('some.group', 'yasomecalalib_2.10', '1.2.5')
+
+        def dependencySet = new DefaultDependencySet(
                     'someDisplayName',
-                    new DefaultDomainObjectSet(Dependency, Arrays.asList(dep1, dep2, dep3)))
+                    new DefaultDomainObjectSet(Dependency, Arrays.asList(dep1, dep2, dep3, dep4)))
         when:
             def tupleList = DependencyInsights.findAllNonMatchingScalaVersionDependencies(dependencySet.collect(), '2.10')
         then:
-            tupleList.size() == 2
+            tupleList.size() == 3
             tupleList[0][0] == 'some.group:somescalalib'
             tupleList[0][1] == '2.11'
             tupleList[0][2] == dep1
             tupleList[1][0] == 'some.group:someotherscalalib'
             tupleList[1][1] == '?'
             tupleList[1][2] == dep2
+            tupleList[2][0] == 'some.group:yasomecalalib'
+            tupleList[2][1] == '?'
+            tupleList[2][2] == dep3
     }
 
     def "When findAllNonMatchingScalaVersionDependenciesWithCounterparts given a dependency set it should return correctly"() {
@@ -55,14 +70,15 @@ class DependencyInsightsTest extends Specification {
             def dep31 = new DefaultExternalModuleDependency('some.group', 'somescalalib_2.10', '1.2.6')
             def dep4 = new DefaultExternalModuleDependency('some.group', 'someotherscalalib_2.11', '1.2.3')
             def dep5 = new DefaultExternalModuleDependency('some.group', 'yasomescalalib_?', '1.2.4')
+            def dep51 = new DefaultExternalModuleDependency('some.group', 'yasomescalalib_?_suffix', '1.2.4')
             def dep6 = new DefaultExternalModuleDependency('some.group', 'nonscalalib', '1.2.5')
             def dependencySet = new DefaultDependencySet(
                     'someDisplayName',
-                    new DefaultDomainObjectSet(Dependency, Arrays.asList(dep1, dep2, dep3, dep31, dep4, dep5, dep6)))
+                    new DefaultDomainObjectSet(Dependency, Arrays.asList(dep1, dep2, dep3, dep31, dep4, dep5, dep51, dep6)))
         when:
             def tuplesList = DependencyInsights.findAllNonMatchingScalaVersionDependenciesWithCounterparts(dependencySet.collect(), '2.10')
         then:
-            tuplesList.size() == 4
+            tuplesList.size() == 5
             tuplesList[0].first[0] == 'some.group:somescalalib'
             tuplesList[0].first[1] == '2.11'
             tuplesList[0].first[2] == dep1
@@ -87,5 +103,13 @@ class DependencyInsightsTest extends Specification {
             tuplesList[2].first[1] == '2.11'
             tuplesList[2].first[2] == dep4
             tuplesList[2].second.size() == 0
+            tuplesList[3].first[0] == 'some.group:yasomescalalib'
+            tuplesList[3].first[1] == '?'
+            tuplesList[3].first[2] == dep5
+            tuplesList[3].second.size() == 0
+            tuplesList[4].first[0] == 'some.group:yasomescalalib'
+            tuplesList[4].first[1] == '?'
+            tuplesList[4].first[2] == dep51
+            tuplesList[4].second.size() == 0
     }
 }


### PR DESCRIPTION
This PR fixes #6 
Resolve the issue where 3rd lib Scala dependency artifact names that ends with let say *_2.11_suffix are not being resolved for all test* type configurations like `testCompileClasspath` for instance, hence failing the build.