### PR TITLE
To use composed method for dependency resolution for scala `?` deps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - $HOME/.gradle/wrapper/
 branches:
   only:
+    - dev
     - master
     - feature/travis_ci
 before_install:

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/ResolutionStrategyConfigurer.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/ResolutionStrategyConfigurer.groovy
@@ -150,7 +150,9 @@ class ResolutionStrategyConfigurer {
                     // Replace 3d party scala dependency which contains '_?'
                     def probableScalaVersion = DependencyInsights.parseDependencyName(requested.name)[1]
                     if (probableScalaVersion == '?') {
-                        resolveQMarkInTargetDependencyName(details, c, scalaVersions)
+                        // We do not have plugin generated cross build configurations specifically dependent on test
+                        // configurations like `testCompile`, `testCompileOnly`, `testImplementation` ...
+                        strategyForNonCrossBuildConfiguration(c, probableScalaVersion, details)
                         project.logger.info(LoggerUtils.logTemplate(project,
                                 "${c.name} | Found crossbuild glob '?' in dependency name ${requested.name}. " +
                                         "Subtituted with [${details.target.name}]"
@@ -236,6 +238,9 @@ class ResolutionStrategyConfigurer {
                     allDependencySet, scalaVersionInsights.artifactInlinedVersion)
             new Tuple2(scalaVersionInsights.artifactInlinedVersion, deps.size())
         }.findAll { tuple ->
+            // Means this is a sane state where the dependency to be resolved does not have any other alternatives in
+            // the dependency set being examined. In that case we can build upon it to infer the scala version up the
+            // stream.
             tuple.second == 0
         }
         def requested = details.requested

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginResolutionStrategyTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginResolutionStrategyTest.groovy
@@ -25,11 +25,13 @@ class CrossBuildPluginResolutionStrategyTest extends CrossBuildGradleRunnerSpec 
     File buildFile
     File propsFile
     File scalaFile
+    File testScalaFile
 
     def setup() {
         buildFile = file('build.gradle')
         propsFile = file('gradle.properties')
         scalaFile = file('src/main/scala/helloWorld.scala')
+        testScalaFile = file('src/test/scala/helloWorldTest.scala')
     }
 
     @Unroll
@@ -130,5 +132,96 @@ dependencies {
         pom211.contains('3.0.1')
         where:
         [gradleVersion, defaultScalaVersion] << [['2.14.1', '2.10'], ['3.0', '2.10'], ['4.1', '2.10'], ['2.14.1', '2.11'], ['3.0', '2.11'], ['4.1', '2.11']]
+    }
+
+    @Unroll
+    def "[gradle:#gradleVersion | default-scala-version:#defaultScalaVersion] applying crossbuild plugin with qmark deps in test configuration should be resolved correctly"() {
+        given:
+        scalaFile << """
+object Lib {
+  val book: scala.xml.Elem = <book id="b20234">Magic of scala-xml</book>
+
+  val id = book \\@ "id"
+  //id: String = b20234
+
+  val text = book.text
+  //text: String = Magic of scala-xml
+}
+"""
+
+        testScalaFile << """
+import java.util.function._
+import scala.compat.java8.FunctionConverters._
+
+object Test {
+  val foo: Int => Boolean = i => i > 7
+  def testBig(ip: IntPredicate) = ip.test(9)
+  println(testBig(foo.asJava))  // Prints true
+
+  val bar = new UnaryOperator[String]{ def apply(s: String) = s.reverse }
+  List("cod", "herring").map(bar.asScala)    // List("doc", "gnirrih")
+
+  def testA[A](p: Predicate[A])(a: A) = p.test(a)
+  println(testA(asJavaPredicate(foo))(4))  // Prints false
+}
+"""
+
+        buildFile << """
+import com.github.prokod.gradle.crossbuild.model.*
+
+plugins {
+    id 'java-library'
+    id 'com.github.prokod.gradle-crossbuild'
+}
+
+repositories {
+    mavenCentral()
+}
+
+model {
+    crossBuild {
+        targetVersions {
+            v211(ScalaVer) {
+                value = '2.11'
+            }
+            v212(ScalaVer) {
+                value = '2.12'
+            }
+        }
+
+        scalaVersions = ['2.11':'2.11.12', '2.12':'2.12.8']
+    }
+}
+
+dependencies {
+    implementation "org.scala-lang:scala-library:${defaultScalaVersion}.+"
+    implementation 'org.scala-lang.modules:scala-xml_?:[1.0, 2.0['
+
+    testImplementation 'org.scala-lang.modules:scala-java8-compat_?:[0.9,1.0['
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.3.2"
+    testImplementation "org.mockito:mockito-core:2.23.4"
+    testImplementation "org.mockito:mockito-junit-jupiter:2.23.4"
+    testImplementation "org.assertj:assertj-core:3.11.1"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.2"
+}
+"""
+
+        when:
+        Assume.assumeTrue(testMavenCentralAccess())
+        def result = GradleRunner.create()
+                .withGradleVersion(gradleVersion)
+                .withProjectDir(dir.root)
+                .withPluginClasspath()
+                .withArguments('build', 'check', '--info', '--stacktrace')
+                .build()
+
+        then:
+        result.task(":test").outcome == SUCCESS
+        result.task(":build").outcome == SUCCESS
+
+        where:
+        [gradleVersion, defaultScalaVersion] << [['4.10.3', '2.11'], ['4.10.3', '2.12']]
     }
 }


### PR DESCRIPTION
This PR close #20 

- Instead of picking specific dependency resolution for `?` scala deps.
  use the composed approach `strategyForNonCrossBuildConfiguration`
  for test* configurations

- Add a test to cover the resolution strategy impl. for test*
  configurations. Also the plugin is being tested against 'java-library'
  configurations (lifecycle).