### PR TITLE
To fix `archive.appendixPattern` propagation from `crossBuild {}` block level

### DIFF
--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/CrossBuildExtension.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/CrossBuildExtension.groovy
@@ -31,7 +31,7 @@ class CrossBuildExtension {
     CrossBuildExtension(Project project) {
         this.project = project
 
-        this.archive = project.objects.newInstance(ArchiveNaming)
+        this.archive = project.objects.newInstance(ArchiveNaming, '_?')
 
         this.builds = project.container(Build) { name ->
             new Build(name, project.container(NamedVersion))
@@ -59,14 +59,11 @@ class CrossBuildExtension {
     }
 
     void updateBuild(Build build) {
-        build.archive = project.objects.newInstance(ArchiveNaming)
-        applyArchiveDefaults(build)
+        build.archive = project.objects.newInstance(ArchiveNaming, '_?')
     }
 
     void applyArchiveDefaults(Build build) {
-        if (build.archive.appendixPattern == null) {
-            build.archive.appendixPattern = this.archive.appendixPattern
-        }
+        build.archive.appendixPattern = this.archive.appendixPattern
     }
 
     void updateExtension(Build build) {

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/model/ArchiveNaming.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/model/ArchiveNaming.groovy
@@ -1,8 +1,15 @@
 package com.github.prokod.gradle.crossbuild.model
 
+import javax.inject.Inject
+
 /**
  * cross build plugin DSL representation for {@code archive.appendixPattern}
  */
 class ArchiveNaming {
-    String appendixPattern = '_?'
+    String appendixPattern
+
+    @Inject
+    ArchiveNaming(String appendixPattern) {
+        this.appendixPattern = appendixPattern
+    }
 }

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/model/ResolvedArchiveNaming.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/model/ResolvedArchiveNaming.groovy
@@ -9,7 +9,7 @@ class ResolvedArchiveNaming extends ArchiveNaming {
     final String appendix
 
     ResolvedArchiveNaming(String appendixPattern, String appendix) {
-        this.appendixPattern = appendixPattern
+        super(appendixPattern)
         this.appendix = appendix
     }
 }

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginCompileMultiModuleTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginCompileMultiModuleTest.groovy
@@ -162,17 +162,17 @@ dependencies {
         expect:
         def build1 = new Build('spark160', new DefaultDomainObjectCollection(NamedVersion, [])).with { b ->
             scalaVersion = '2.10'
-            archive = new ArchiveNaming(appendixPattern: eap1)
+            archive = new ArchiveNaming(eap1)
             b
         }
         def build2 = new Build('spark240', new DefaultDomainObjectCollection(NamedVersion, [])).with { b ->
             scalaVersion = '2.11'
-            archive = new ArchiveNaming(appendixPattern: eap2)
+            archive = new ArchiveNaming(eap2)
             b
         }
         def build3 = new Build('spark241', new DefaultDomainObjectCollection(NamedVersion, [])).with { b ->
             scalaVersion = '2.12'
-            archive = new ArchiveNaming(appendixPattern: eap3)
+            archive = new ArchiveNaming(eap3)
             b
         }
         def expected = [build1, build2, build3].collect {it.toString()}.join('\n')

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginTest.groovy
@@ -75,7 +75,7 @@ plugins {
 
 crossBuild {
     archive {
-        appendixPattern = '_?'
+        appendixPattern = '-2-4-3_?'
     }
     builds {
         v211
@@ -97,6 +97,8 @@ crossBuild {
         !result.output.contains('publishCrossBuild211PublicationToMavenLocal')
         result.output.contains('crossBuild212Jar')
         !result.output.contains('publishCrossBuild212PublicationToMavenLocal')
+        result.output.contains('-2-4-3_2.11]')
+        result.output.contains('-2-4-3_2.12]')
         result.task(":tasks").outcome == SUCCESS
 
         where:


### PR DESCRIPTION
This PR closes #32 