### PR TITLE
made compile only dependencies provided as default gradle code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/prokod/gradle-crossbuild-scala.svg?branch=master)](https://travis-ci.org/prokod/gradle-crossbuild-scala)
 [![codecov](https://codecov.io/gh/prokod/gradle-crossbuild-scala/branch/master/graph/badge.svg)](https://codecov.io/gh/prokod/gradle-crossbuild-scala)
 [![Automated Release Notes by gren](https://img.shields.io/badge/%F0%9F%A4%96-release%20notes-00B2EE.svg)](https://github-tools.github.io/github-release-notes/)
-[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/prokod/gradle-crossbuild/com.github.prokod.gradle-crossbuild.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=gradle%20plugin)](https://plugins.gradle.org/plugin/com.github.prokod.gradle-crossbuild)
+[![Gradle Plugin Portal](https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&url=https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/prokod/gradle-crossbuild/com.github.prokod.gradle-crossbuild.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=gradle%20plugin)](https://plugins.gradle.org/plugin/com.github.prokod.gradle-crossbuild)
 
 ## Features
 - **Multi-module projects support** Supports both simple projects and multi-module projects.<br>In multi-module projects support mixed cases where only some of the modules needs cross compiling.
@@ -36,7 +36,7 @@ buildscript {
 ## Quick start
 ### recommended cross building apply strategy
 This is especially true for multi module projects but not just.<br/>
-- Wire up your build scripts in the project in such a way that you are able to successfully build it for single scala version.<br/> Beware that this plugin does not support `api` configuration so avoid using it, for further details see [java-library related section](#build_scenarios).
+- Wire up your build scripts in the project in such a way that you are able to successfully build it for single scala version.<br/> Beware that this plugin does not support `api` configuration so avoid using it, for further details see [java-library related section](#java_library).
   > **_NOTE:_** Do not worry in this stage about publishing artifacts as cross building with publishing is supported by the plugin.<br/>It will be some what wasted effort to do that here and then modify it to the cross build scenario.
 - After that add the cross building plugin without changing any of the inter and external dependencies. Follow base step - [getting the plugin](#getting_plugin) and then configure it, see please both [plugin configuration options](#plugin_configuration_options) and [basic plugin configuration](#basic_plugin_configuration)
   > **_NOTE:_** If you have to change your dependencies because of applying the plugin and trying explicitly `gradle build`, something is fishy.<br/>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 #### Using the plugin DSL:
 ```groovy
 plugins {
-    id "com.github.prokod.gradle-crossbuild" version "0.8.2"
+    id "com.github.prokod.gradle-crossbuild" version "0.9.0"
 }
 ```  
     
@@ -28,7 +28,7 @@ plugins {
 ```groovy
 buildscript {
     dependencies {
-        classpath("com.github.prokod:gradle-crossbuild-scala:0.8.2")
+        classpath("com.github.prokod:gradle-crossbuild-scala:0.9.0")
     }
 }
 ```
@@ -282,7 +282,7 @@ To apply cross building to a multi-module project use one of the following sugge
 - In the root project build.gradle:
 ```groovy
 plugins {
-    id "com.github.prokod.gradle-crossbuild" version '0.8.2' apply false
+    id "com.github.prokod.gradle-crossbuild" version '0.9.0' apply false
 }
 
 allprojects {
@@ -330,7 +330,7 @@ apply plugin: 'com.github.prokod.gradle-crossbuild'
 - In the root project build.gradle:
 ```groovy
 plugins {
-    id "com.github.prokod.gradle-crossbuild" version '0.8.2' apply false
+    id "com.github.prokod.gradle-crossbuild" version '0.9.0' apply false
 }
 
 allprojects {
@@ -380,5 +380,5 @@ subprojects {
 ### Supported Gradle versions
 |plugin version | Tested Gradle versions |
 |---------------|------------------------|
-|0.8.x          | 4.2, 4.10.3, 5.4.1     |
+|0.9.x          | 4.2, 4.10.3, 5.4.1     |
 |0.4.x          | 2.14, 3.0, 4.1         |

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ how the builds are resolved in the pom file
 | type | pom  |
 | ------ | ----- |
 | compile | compile |
-| compileOnly | provided |
+| compileOnly | ignored, not added to the pom file |
 | annotationProcessor | ignored, not added to the pom file|
 | runtimeOnly | runtime |
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ dependencies {
   The other dependency specified for Scala versions **2.10**, **2.11** respectively (`crossBuild210Compile/Only`, `crossBuild211Compile/Only`), will be used only for `crossBuild210Jar`, `crossBuild211Jar`, and other corresponding task variants (`publishCrossBuild210PublicationToMavenLocal`, `publishCrossBuild211PublicationToMavenLocal` ...)<br/>
 > - The plugin provides pre defined configurations (sourceSets) being used by the matching pre generated Jar tasks:<br/>
   crossBuild211Jar -> crossBuild211Compile, crossBuild211CompileOnly, ...
+### pom result
+how the builds are resolved in the pom file
+
+| type | pom  |
+| ------ | ----- |
+| compile | compile |
+| compileOnly | provided |
+| annotationProcessor | ignored, not added to the pom file|
+| runtimeOnly | runtime |
+
 
 ## <a name="build_scenarios"></a>`builds {}` -> Gradle SourceSets, Configurations and Tasks
 The following table shows some commonly build scenarios expressed through the plugin DSL and how they are actually resolved

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'signing'
 apply plugin: 'codenarc'
 
 group = 'com.github.prokod'
-version = '0.9.0-SNAPSHOT'
+version = '0.9.0'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'signing'
 apply plugin: 'codenarc'
 
 group = 'com.github.prokod'
-version = '0.9.0'
+version = '0.9.1'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'codenarc'
 
-
 group = 'com.github.prokod'
 version = '0.9.0-SNAPSHOT'
 

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/AbstractCrossBuildPomTask.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/AbstractCrossBuildPomTask.groovy
@@ -30,6 +30,7 @@ abstract class AbstractCrossBuildPomTask extends DefaultTask {
     static enum ScopeType {
         COMPILE,
         RUNTIME,
-        PROVIDED
+        PROVIDED,
+        COMPILE_ONLY
     }
 }

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/CrossBuildPomTask.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/CrossBuildPomTask.groovy
@@ -47,8 +47,10 @@ class CrossBuildPomTask extends AbstractCrossBuildPomTask {
                 switch (scope) {
                     case ScopeType.COMPILE:
                         return crossBuildSourceSet.compileClasspathConfigurationName
-                    case ScopeType.PROVIDED:
+                    case ScopeType.COMPILE_ONLY:
                         return crossBuildSourceSet.compileOnlyConfigurationName
+                    case ScopeType.PROVIDED:
+                        return []
                     case ScopeType.RUNTIME:
                         return crossBuildSourceSet.runtimeClasspathConfigurationName
                 }
@@ -98,7 +100,7 @@ class CrossBuildPomTask extends AbstractCrossBuildPomTask {
 
                 case ScopeType.COMPILE:
                     def compileModuleDeps = resolveSourceSet(ScopeType.COMPILE)
-                    def inProvidedSourceSet = dependencyFilter(ScopeType.PROVIDED)
+                    def inProvidedSourceSet = dependencyFilter(ScopeType.COMPILE_ONLY)
 
                     // If this is called and there were no repositories defined, an Exception will be raised
                     // Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Cannot resolve external

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/CrossBuildPomTask.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/tasks/CrossBuildPomTask.groovy
@@ -65,11 +65,11 @@ class CrossBuildPomTask extends AbstractCrossBuildPomTask {
         }
 
         def dependencyFilter = { ScopeType scope ->
-            def set = resolveSourceSet(scope)
+            def dependencies = resolveSourceSet(scope)
                 .collect { it -> toComparableDependency(it) };
 
            { ResolvedDependency dep ->
-               set.contains(toComparableDependency(dep))
+               dependencies.contains(toComparableDependency(dep))
            }
         }
 
@@ -131,11 +131,11 @@ class CrossBuildPomTask extends AbstractCrossBuildPomTask {
                 msg:"Created Maven scope ${scopeType} related configuration: ${createdTargetMavenScopeConfig.name}"
         ))
 
-        set(createdTargetMavenScopeConfig, dependencySetFunction(scopeType).toSet())
+        setDependencies(createdTargetMavenScopeConfig, dependencySetFunction(scopeType).toSet())
         new Tuple2<>(scopeType, createdTargetMavenScopeConfig)
     }
 
-    private void set(Configuration target, Set<Dependency> sourceDependencies) {
+    private void setDependencies(Configuration target, Set<Dependency> sourceDependencies) {
         target.dependencies.addAll(sourceDependencies)
     }
 

--- a/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginPomGenTest.groovy
+++ b/src/test/groovy/com/github/prokod/gradle/crossbuild/CrossBuildPluginPomGenTest.groovy
@@ -130,7 +130,7 @@ if(gradle.gradleVersion != '4.2'){
             }
         println(project210)
         then:
-        project210.size() == 4
+        project210.size() == 3
         project210['org.scala-lang'].groupId == 'org.scala-lang'
         project210['org.scala-lang'].artifactId == 'scala-library'
         project210['org.scala-lang'].version == ScalaVersions.DEFAULT_SCALA_VERSIONS.catalog['2.10']
@@ -143,10 +143,7 @@ if(gradle.gradleVersion != '4.2'){
         project210['com.google.guava'].artifactId == 'guava'
         project210['com.google.guava'].version == '18.0'
         project210['com.google.guava'].scope == 'compile'
-        project210['org.apache.spark'].groupId == 'org.apache.spark'
-        project210['org.apache.spark'].artifactId == 'spark-sql_2.10'
-        project210['org.apache.spark'].version == '1.6.3'
-        project210['org.apache.spark'].scope == 'provided'
+
         when:
         def project211 = new XmlSlurper().parseText(pom211)
             .dependencies
@@ -156,7 +153,7 @@ if(gradle.gradleVersion != '4.2'){
             }
 
         then:
-        project211.size() == 4
+        project211.size() == 3
         project211['org.scalatest'].groupId == 'org.scalatest'
         project211['org.scalatest'].artifactId == 'scalatest_2.11'
         project211['org.scalatest'].version == '3.0.1'
@@ -169,10 +166,7 @@ if(gradle.gradleVersion != '4.2'){
         project211['org.scala-lang'].artifactId == 'scala-library'
         project211['org.scala-lang'].version == ScalaVersions.DEFAULT_SCALA_VERSIONS.catalog['2.11']
         project211['org.scala-lang'].scope == 'compile'
-        project211['org.apache.spark'].groupId == 'org.apache.spark'
-        project211['org.apache.spark'].artifactId == 'spark-sql_2.11'
-        project211['org.apache.spark'].version == '2.2.1'
-        project211['org.apache.spark'].scope == 'provided'
+
         where:
         gradleVersion   | defaultScalaVersion
         '4.2'           | '2.10'


### PR DESCRIPTION
Hey,

I really enjoy your library to do cross compilation on for scala projects and i think this should become the default scala plugin for gradle. Atleast how the feature is implemented.

At our company we where doing some work with cross compilation and graal and we found out that `compileOnly` dependencies are added to the pom as a `compile` dependency. This meant that our app included the full graal vm and failed durring build time.

The same thing applies to spark that the spark jar will be included in the fat jar which is not recommended.

So to resolve this i changed to code so compileOnly dependencies are added to the pom as `provided`.

I also added an entry in the README to show what types become what pom types. Because i was unable to override this behavior of your plugin.

I also did some boyscouting.

Kind regards, Boris Smidt
