### PR TITLE
reducing the amount of configs needed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'signing'
 apply plugin: 'codenarc'
 
 group = 'com.github.prokod'
-version = '0.12.0'
+version = '0.12.1'
 
 repositories {
     jcenter()

--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/ResolutionStrategyConfigurer.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/ResolutionStrategyConfigurer.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.artifacts.DependencySet
 
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Crossbuild Configuration resolution strategy configurer
@@ -126,7 +125,6 @@ class ResolutionStrategyConfigurer {
     private void strategyForCrossBuildConfiguration(DependencyResolveDetails details,
                                                     String supposedScalaVersion,
                                                     SourceSetInsightsView insightsView) {
-        def project = sourceSetInsights.project
 
         def crossBuildConfiguration = insightsView.configurations.crossBuild
         def crossBuildConfigurationName = crossBuildConfiguration.name


### PR DESCRIPTION
I think it still needs some work but it at least reduces the amount of these closures. Since it slows down the dependency resolution a lot. i..e for all calls of all dependnecies every closure is executed.
The amount of these registrations should be reduced and i think those big sets of dependencies is what eventually makes gradle crawl.
I.e. i got a OOM when i had a project with 30 sub projects.

This already reduces it by a square root of amount. i.e. before it was applied for every project by every project and for all configs.
so for 30 projects with more then 20 configurations each it becomes huge very fast. 

It might be that the deamon doesn't clean the state and thus creates a memory leak.

could you have another look on how we can reduce the amount of dependency rules. 